### PR TITLE
Additional make targets for logs and termination

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,9 +83,6 @@ else
 	--container job-runner --execution $(JOB_EXECUTION_NAME) --format text
 endif
 
-# Note, if JOB_EXECUTION_NAME is provided, this target will currently raise a JSONDecodeError due to a known, 
-# unresolved issue with the Azure CLI. See https://github.com/Azure/azure-cli/issues/29849.
-# Despite this, the job will still be stopped.
 .PHONY: kill-job
 kill-job: get-deployment-vars
 ifndef JOB_EXECUTION_NAME

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,30 @@ else
 	--job-execution-name $(JOB_EXECUTION_NAME) --output table
 endif
 
+.PHONY: tail-job-log
+tail-job-log: get-deployment-vars
+ifndef JOB_EXECUTION_NAME
+	@echo "Fetching logs for default execution."
+	az containerapp job logs show -n job-runner -g $(DEPLOYMENT_RG) --subscription $(DEPLOYMENT_SUBSCRIPTION) \
+	--container job-runner --format text
+else
+	az containerapp job logs show -n job-runner -g $(DEPLOYMENT_RG) --subscription $(DEPLOYMENT_SUBSCRIPTION) \
+	--container job-runner --execution $(JOB_EXECUTION_NAME) --format text
+endif
+
+# Note, if JOB_EXECUTION_NAME is provided, this target will currently raise a JSONDecodeError due to a known, 
+# unresolved issue with the Azure CLI. See https://github.com/Azure/azure-cli/issues/29849.
+# Despite this, the job will still be stopped.
+.PHONY: kill-job
+kill-job: get-deployment-vars
+ifndef JOB_EXECUTION_NAME
+	@echo "Killing default job (latest)."
+	az containerapp job stop -n job-runner -g $(DEPLOYMENT_RG) --subscription $(DEPLOYMENT_SUBSCRIPTION)
+else
+	az containerapp job stop -n job-runner -g $(DEPLOYMENT_RG) --subscription $(DEPLOYMENT_SUBSCRIPTION) \
+	--job-execution-name $(JOB_EXECUTION_NAME)
+endif
+
 #################
 ### TALOS JOB
 .PHONY: push-talos-job


### PR DESCRIPTION
Added two additional Makefile targets to help with job management and debugging.

Note: when specifying a `job-execution-name` parameter for `az containerapp job stop` in the `kill-job` target, the Azure CLI may raise a `JSONDecodeError` due to a known issue. It appears that despite an HTTP response code of 200, the body of the underlying API call to sop the Container App job is empty and the `az cli` throws an error trying to parse this as JSON. Despite this, the actual request to stop the job is processed, so the command is successful though not graceful. @gregsmi if you have suggestions for how to better address, please feel free to comment or push additional commits.   

